### PR TITLE
[Resize] Use native SizeF instead of own struct

### DIFF
--- a/src/Community.Components/Components/Resizer/ResizedEventArgs.cs
+++ b/src/Community.Components/Components/Resizer/ResizedEventArgs.cs
@@ -1,4 +1,4 @@
-using FluentUI.Blazor.Community.Geometry;
+using System.Drawing;
 
 namespace FluentUI.Blazor.Community.Components;
 

--- a/src/Community.Components/Geometry/SizeF.cs
+++ b/src/Community.Components/Geometry/SizeF.cs
@@ -1,8 +1,0 @@
-namespace FluentUI.Blazor.Community.Geometry;
-
-public struct SizeF
-{
-    public float Width { get; set; }
-
-    public float Height { get; set; }
-}


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR removes the custom `SizeF` type and uses the built in `SizeF` type from `System.Drawing` namespace.



## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component


