### PR TITLE
Fix sizing of Filemanager in documentation navigation

### DIFF
--- a/examples/demo/FluentUI.Demo.Shared/Layout/DemoNavMenu.razor
+++ b/examples/demo/FluentUI.Demo.Shared/Layout/DemoNavMenu.razor
@@ -7,7 +7,7 @@
             <FluentNavLink Href="dropzones" Icon="@(new Icons.Regular.Size20.Drop())" IconColor="Color.Accent">Dropzones</FluentNavLink>
             <FluentNavLink Href="resizers" Icon="@(new Icons.Regular.Size20.Resize())" IconColor="Color.Accent">Resizers</FluentNavLink>
             <FluentNavLink Href="tilegrid" Icon="@(new Icons.Regular.Size20.Apps())" IconColor="Color.Accent">Tile Grid</FluentNavLink>
-            <FluentNavLink Href="filemanager" Icon="@(new FileIcons.Size128.DefaultFileIcon())" IconColor="Color.Accent">File Manager</FluentNavLink>
+            <FluentNavLink Href="filemanager" Icon="@(new Icons.Regular.Size20.FolderOpen())" IconColor="Color.Accent">File Manager</FluentNavLink>
             <FluentNavLink Href="charts" IconColor="Color.Accent" Icon="@(new Icons.Regular.Size20.ChartMultiple())">Charts</FluentNavLink>
             <FluentNavLink Href="imagegroup" IconColor="Color.Accent" Icon="@(new Icons.Regular.Size20.ImageMultiple())">Image group</FluentNavLink>
         </FluentNavMenu>


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixes the sizing of FileManager icon in the documentation navigation.

