### PR TITLE
Add inheritdoc to supress some warnings

### DIFF
--- a/src/Community.Components/Components/DeviceDetector/FluentCxDeviceDetector.razor.cs
+++ b/src/Community.Components/Components/DeviceDetector/FluentCxDeviceDetector.razor.cs
@@ -22,7 +22,7 @@ public partial class FluentCxDeviceDetector
     /// </summary>
     private const string JavascriptFileName = "./_content/FluentUI.Blazor.Community.Components/Components/DeviceDetector/FluentCxDeviceDetector.razor.js";
 
-    public FluentCxDeviceDetector()
+    public FluentCxDeviceDetector() : base()
     {
         _deviceDetectorReference = DotNetObjectReference.Create(this);
     }
@@ -37,7 +37,7 @@ public partial class FluentCxDeviceDetector
     /// Gets or sets the Javascript Runtime.
     /// </summary>
     [Inject]
-    public required IJSRuntime JSRuntime { get; set; }
+    private IJSRuntime JSRuntime { get; set; }
 
     /// <summary>
     /// Gets the information of the running device.

--- a/src/Community.Components/Components/DropZone/FluentCxDropZone.razor.cs
+++ b/src/Community.Components/Components/DropZone/FluentCxDropZone.razor.cs
@@ -186,6 +186,7 @@ public partial class FluentCxDropZone<TItem>
         await InvokeAsync(DropZoneContainer.Refresh);
     }
 
+    /// <inheritdoc />
     protected override void OnInitialized()
     {
         base.OnInitialized();
@@ -196,6 +197,7 @@ public partial class FluentCxDropZone<TItem>
         }
     }
 
+    /// <inheritdoc />
     public void Dispose()
     {
         if (AddInContainer)

--- a/src/Community.Components/Components/FileManager/FileManager.razor.cs
+++ b/src/Community.Components/Components/FileManager/FileManager.razor.cs
@@ -111,6 +111,7 @@ public partial class FileManager<TItem>
         }
     }
 
+    /// <inheritdoc />
     public override async Task SetParametersAsync(ParameterView parameters)
     {
         await base.SetParametersAsync(parameters);
@@ -128,6 +129,7 @@ public partial class FileManager<TItem>
         _isBusy = isBusy;
     }
 
+    /// <inheritdoc />
     protected override void OnInitialized()
     {
         base.OnInitialized();
@@ -136,6 +138,7 @@ public partial class FileManager<TItem>
         State.OnViewUpdated += OnViewUpdated;
     }
 
+    /// <inheritdoc />
     public void Dispose()
     {
         State.OnSortUpdated -= OnUpdated;

--- a/src/Community.Components/Components/FileManager/FileManagerEntryDetails.razor.cs
+++ b/src/Community.Components/Components/FileManager/FileManagerEntryDetails.razor.cs
@@ -55,6 +55,7 @@ public partial class FileManagerEntryDetails<TItem> where TItem : class, new()
         return $"data:{contentType};base64,{Convert.ToBase64String(data)}";
     }
 
+    /// <inheritdoc />
     protected override void OnInitialized()
     {
         base.OnInitialized();
@@ -62,6 +63,7 @@ public partial class FileManagerEntryDetails<TItem> where TItem : class, new()
         _fileExtensionTypeProvider = new(FileExtensionTypeLabels);
     }
 
+    /// <inheritdoc />
     protected override async Task OnParametersSetAsync()
     {
         _entryDataContent = [];

--- a/src/Community.Components/Components/FileManager/FileMoverDialog.razor.cs
+++ b/src/Community.Components/Components/FileManager/FileMoverDialog.razor.cs
@@ -50,6 +50,7 @@ public partial class FileMoverDialog<TItem> : IDialogContentComponent<FileManage
         };
     }
 
+    /// <inheritdoc />
     protected override void OnInitialized()
     {
         base.OnInitialized();

--- a/src/Community.Components/Components/FileManager/FluentCxFileManager.razor.cs
+++ b/src/Community.Components/Components/FileManager/FluentCxFileManager.razor.cs
@@ -49,10 +49,10 @@ public partial class FluentCxFileManager<TItem>
     internal FileManagerState State { get; set; } = default!;
 
     [Inject]
-    private IJSRuntime JSRuntime { get; set; }
+    private IJSRuntime JSRuntime { get; set; } = default!;
 
     [Inject]
-    private IDialogService DialogService { get; set; }
+    private IDialogService DialogService { get; set; } = default!;
 
     [Parameter]
     public string? Width { get; set; }

--- a/src/Community.Components/Components/FileManager/FluentCxFileManager.razor.cs
+++ b/src/Community.Components/Components/FileManager/FluentCxFileManager.razor.cs
@@ -49,10 +49,10 @@ public partial class FluentCxFileManager<TItem>
     internal FileManagerState State { get; set; } = default!;
 
     [Inject]
-    public required IJSRuntime JSRuntime { get; set; }
+    private IJSRuntime JSRuntime { get; set; }
 
     [Inject]
-    public required IDialogService DialogService { get; set; }
+    private IDialogService DialogService { get; set; }
 
     [Parameter]
     public string? Width { get; set; }

--- a/src/Community.Components/Components/ImageGroup/FluentCxImage.razor.cs
+++ b/src/Community.Components/Components/ImageGroup/FluentCxImage.razor.cs
@@ -40,6 +40,7 @@ public partial class FluentCxImage
 
     internal RenderFragment InternalRenderer { get; set; }
 
+    /// <inheritdoc />
     public ValueTask DisposeAsync()
     {
         Parent.Remove(this);
@@ -55,12 +56,14 @@ public partial class FluentCxImage
         Parent.OnItemParemetersChanged(this);
     }
 
+    /// <inheritdoc />
     protected override void OnInitialized()
     {
         base.OnInitialized();
         Parent.Add(this);
     }
 
+    /// <inheritdoc />
     protected override void OnAfterRender(bool firstRender)
     {
         base.OnAfterRender(firstRender);
@@ -71,6 +74,7 @@ public partial class FluentCxImage
         }
     }
 
+    /// <inheritdoc />
     protected override void OnParametersSet()
     {
         base.OnParametersSet();
@@ -83,6 +87,7 @@ public partial class FluentCxImage
         }
     }
 
+    /// <inheritdoc />
     public override Task SetParametersAsync(ParameterView parameters)
     {
         _hasParameterChanged = parameters.HasValueChanged(nameof(Width), Width) ||

--- a/src/Community.Components/Components/ImageGroup/FluentCxImageGroup.razor.cs
+++ b/src/Community.Components/Components/ImageGroup/FluentCxImageGroup.razor.cs
@@ -104,6 +104,7 @@ public partial class FluentCxImageGroup
         StateHasChanged();
     }
 
+    /// <inheritdoc />
     public override async Task SetParametersAsync(ParameterView parameters)
     {
         await base.SetParametersAsync(parameters);

--- a/src/Community.Components/Components/Resizer/FluentCxResizer.razor.cs
+++ b/src/Community.Components/Components/Resizer/FluentCxResizer.razor.cs
@@ -28,7 +28,7 @@ public partial class FluentCxResizer
     public EventCallback<ResizedEventArgs> OnResized { get; set; }
 
     [Inject]
-    private IJSRuntime JSRuntime { get; set; }
+    private IJSRuntime JSRuntime { get; set; } = default!;
 
     [Parameter]
     public LocalizationDirection LocalizationDirection { get; set; } = LocalizationDirection.LeftToRight;

--- a/src/Community.Components/Components/Resizer/FluentCxResizer.razor.cs
+++ b/src/Community.Components/Components/Resizer/FluentCxResizer.razor.cs
@@ -28,7 +28,7 @@ public partial class FluentCxResizer
     public EventCallback<ResizedEventArgs> OnResized { get; set; }
 
     [Inject]
-    public required IJSRuntime JSRuntime { get; set; }
+    private IJSRuntime JSRuntime { get; set; }
 
     [Parameter]
     public LocalizationDirection LocalizationDirection { get; set; } = LocalizationDirection.LeftToRight;
@@ -69,6 +69,7 @@ public partial class FluentCxResizer
         }
     }
 
+    /// <inheritdoc />
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         await base.OnAfterRenderAsync(firstRender);
@@ -96,6 +97,7 @@ public partial class FluentCxResizer
         }
     }
 
+    /// <inheritdoc />
     public override async Task SetParametersAsync(ParameterView parameters)
     {
         await base.SetParametersAsync(parameters);
@@ -106,6 +108,7 @@ public partial class FluentCxResizer
         }
     }
 
+    /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
         try


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR add inheritdoc to internal blazor methods to supress warning for missing documentation.

Injected services have been marked as private instead of public to supress warnings as well and to not show the properties in the docs.


## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps
There is still a lot of code documentation to do.
