### PR TITLE
Do not start publishing when opening a pull request

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -6,8 +6,6 @@ name: github pages
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
   build:


### PR DESCRIPTION
I forgot to remove the `pull_request` trigger from the workflow. Right now it publishes main branch whenever a pull request is being opened.