### PR TITLE
Correct an issue with many dragenter events occur where a bigger tile…

### DIFF
--- a/src/Community.Components/Components/Internal/DropZone/FluentCxDropZone.cs
+++ b/src/Community.Components/Components/Internal/DropZone/FluentCxDropZone.cs
@@ -11,6 +11,7 @@ internal class FluentCxDropZone<TItem>
     : FluentComponentBase, IDisposable, IItemValue<TItem>
 {
     internal readonly RenderFragment _renderDropZone;
+    private bool _dragEnter;
 
     public FluentCxDropZone()
     {
@@ -202,9 +203,9 @@ internal class FluentCxDropZone<TItem>
 
     private void OnDragLeave()
     {
+        _dragEnter = false;
         State.TargetItem = default!;
         DropZoneContainer.Refresh();
-        Console.WriteLine($"Leave {Value}");
     }
 
     private async Task OnDragEndAsync()
@@ -228,6 +229,12 @@ internal class FluentCxDropZone<TItem>
 
     private async Task OnDragEnterAsync()
     {
+        if (_dragEnter)
+        {
+            return;
+        }
+
+        _dragEnter = true;
         var activeItem = State.ActiveItem;
 
         if (activeItem is null)
@@ -251,7 +258,6 @@ internal class FluentCxDropZone<TItem>
         }
 
         State.TargetItem = Value;
-        Console.WriteLine($"Enter {Value}");
 
         if (DropZoneContainer.Immediate)
         {


### PR DESCRIPTION
… is dragged into a smaller tile

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

Sometimes when a bigger tile is dragged into a smaller tile, dragenter is called many times which cause a flashy reordering.
(bigger -> smaller, smaller -> bigger, looping swap tiles)

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
