### PR TITLE
adds a grid layout on the fluentcxdropzonecontainer

### DIFF
--- a/examples/demo/FluentUI.Demo.Shared/FluentUI.Blazor.Community.Components.xml
+++ b/examples/demo/FluentUI.Demo.Shared/FluentUI.Blazor.Community.Components.xml
@@ -5162,6 +5162,14 @@
             Gets or sets if the layout is persisted.
             </summary>
         </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.CheckEquality(`0,`0)">
+            <summary>
+            Checks equality between two items.
+            </summary>
+            <param name="left">Left item to compare.</param>
+            <param name="right">Right item to compare.</param>
+            <returns>Returns <see langword="true" /> if the items are equal, <see langword="false" /> otherwise.</returns>
+        </member>
         <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.OnDropAsync(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
             <summary>
             Occurs when an item is dropped into the component.
@@ -5579,6 +5587,11 @@
         <member name="F:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1._module">
             <summary>
             Represents the reference of the javascript object. 
+            </summary>
+        </member>
+        <member name="F:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1._layoutLoaded">
+            <summary>
+            Represents a value indicating if the layout was already loaded.
             </summary>
         </member>
         <member name="M:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1.#ctor">

--- a/examples/demo/FluentUI.Demo.Shared/FluentUI.Blazor.Community.Components.xml
+++ b/examples/demo/FluentUI.Demo.Shared/FluentUI.Blazor.Community.Components.xml
@@ -4414,6 +4414,95 @@
         <member name="P:FluentUI.Blazor.Community.Components.UploadFileEventArgs.Extension">
             <summary>Extension of the file.</summary>
         </member>
+        <member name="T:FluentUI.Blazor.Community.Components.GridLayoutBase">
+            <summary>
+            Represents a base for a grid layout.
+            </summary>
+        </member>
+        <member name="F:FluentUI.Blazor.Community.Components.GridLayoutBase._items">
+            <summary>
+            Represents the items inside the layout.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.GridLayoutBase.Items">
+            <summary>
+            Gets the items inside the layout.
+            </summary>
+        </member>
+        <member name="E:FluentUI.Blazor.Community.Components.GridLayoutBase.SaveRequested">
+            <summary>
+            Event to invoke when a save is requested.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.GridLayoutBase.IsDirty">
+            <summary>
+            Gets or sets a value indicating is dirty or not.
+            </summary>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.GridLayoutBase.Get``1(System.String)">
+            <summary>
+            Gets the item from its key.
+            </summary>
+            <typeparam name="T">Type of the item.</typeparam>
+            <param name="key">Key to find.</param>
+            <returns>Returns the item if found, <see langword="false" /> otherwise.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.GridLayoutBase.AddRange(System.Collections.Generic.IEnumerable{FluentUI.Blazor.Community.Components.GridLayoutBaseItem})">
+            <summary>
+            Adds a range of <paramref name="items"/> into the layout.
+            </summary>
+            <param name="items">Items to add.</param>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.GridLayoutBase.Add``1(System.String,System.Int32)">
+            <summary>
+            Adds an item into the layout.
+            </summary>
+            <typeparam name="T">Type of the item.</typeparam>
+            <param name="key">Key of the item.</param>
+            <param name="index">Index of the item.</param>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.GridLayoutBase.Remove(System.Int32)">
+            <summary>
+            Removes an item from its index.
+            </summary>
+            <param name="index">Index to remove.</param>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.GridLayoutBase.GetEnumerator">
+            <inheritdoc />
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.GridLayoutBase.System#Collections#IEnumerable#GetEnumerator">
+            <inheritdoc />
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.GridLayoutBase.RequestSave">
+            <summary>
+            Request a save.
+            </summary>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.GridLayoutBase.Update``1(System.Func{``0,System.String},System.Collections.Generic.IList{``0})">
+            <summary>
+            Updates the items.
+            </summary>
+            <typeparam name="TItem">Type of the items.</typeparam>
+            <param name="keyFunc">Function to extract a key from an item.</param>
+            <param name="items">Items to rearrange.</param>
+            <exception cref="T:System.InvalidOperationException">Occurs when <paramref name="keyFunc"/> is
+             <see langword="null" />.</exception>
+        </member>
+        <member name="T:FluentUI.Blazor.Community.Components.GridLayoutBaseItem">
+            <summary>
+            Represents an item of a <see cref="T:FluentUI.Blazor.Community.Components.GridLayoutBase"/>.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.GridLayoutBaseItem.Index">
+            <summary>
+            Gets or sets the index of the item.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.GridLayoutBaseItem.Key">
+            <summary>
+            Gets or sets the key of the item.
+            </summary>
+        </member>
         <member name="T:FluentUI.Blazor.Community.Components.FluentCxImageGroup">
             <summary>
             Represents a group of images.
@@ -4769,6 +4858,62 @@
             Reset the drop zone.
             </summary>
         </member>
+        <member name="T:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1">
+            <summary>
+            Represents the drop zone component.
+            </summary>
+            <typeparam name="TItem">Type of the item.</typeparam>
+        </member>
+        <member name="F:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1._renderDropZone">
+            <summary>
+            Represents the fragment to render the drop zone.
+            </summary>
+        </member>
+        <member name="F:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1._dragEnter">
+            <summary>
+            Represents a value indicating if the cursor enters into the component.
+            </summary>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1"/>.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.DropZoneContainer">
+            <summary>
+            Gets or sets the parent component.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.ChildContent">
+            <summary>
+            Gets or sets the child content.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.ItemCss">
+            <summary>
+            Gets or sets the css for the item.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.IsDragAllowed">
+            <summary>
+            Gets or sets a value indicating if the component can be dragged.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.IsItemDropAllowed">
+            <summary>
+            Gets or sets a value indicating if the component can be dropped.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.State">
+            <summary>
+            Gets the state of the parent container.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.Value">
+            <summary>
+            Gets or sets the value of the component.
+            </summary>
+        </member>
         <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.ForceRender">
             <summary>
             Gets or sets a value indicating wether the component will render. 
@@ -4787,6 +4932,81 @@
             You mustn't use it.
             </remarks>
         </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.Index">
+            <summary>
+            Gets the index of the current component inside the container.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.Component">
+            <summary>
+            Gets the render of the current component.
+            </summary>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.GetItemStyle">
+            <summary>
+            Gets the style of the item.
+            </summary>
+            <returns>Returns the style of the item.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.GetItemCss">
+            <summary>
+            Gets the css of the item.
+            </summary>
+            <returns>Returns the css of the item.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.GetIsDragTargetDenied">
+            <summary>
+            Gets the value indicating if the target is not allowed to be dragged.
+            </summary>
+            <returns>Returns <see langword="true" /> if the target cannot be dragged, <see langword="false" /> otherwise.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.GetIsDragTarget">
+            <summary>
+            Gets a value indicating if the target can be dragged.
+            </summary>
+            <returns>Returns <see langword="true" /> if the target can be dragged, <see langword="false" /> otherwise.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.GetPlaceholderCss(System.Int32)">
+            <summary>
+            Gets the css for the placeholder.
+            </summary>
+            <param name="index">Index of the placeholder.</param>
+            <returns>Returns the css of the placeholder.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.OnDragLeave">
+            <summary>
+            Occurs when the component leaves a drop zone.
+            </summary>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.OnDragEndAsync">
+            <summary>
+            Occurs when the user has finished dragging the component.
+            </summary>
+            <returns>Returns a task which completes the drag.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.OnDropItemOnPlaceholderAsync(System.Int32)">
+            <summary>
+            Occurs when the components drops into a valid placeholder.
+            </summary>
+            <param name="index">Index of the placeholder.</param>
+            <returns>Returns a task which process the placeholder when completed.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.OnDragStart">
+            <summary>
+            Occurs when the drag starts.
+            </summary>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.OnDragEnterAsync">
+            <summary>
+            Occurs when the component enters a valid drop zone.
+            </summary>
+            <returns>Returns a task which swap the components when completed.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.RenderInternal">
+            <summary>
+            Force the rendering of the component.
+            </summary>
+        </member>
         <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.OnInitialized">
             <inheritdoc />
         </member>
@@ -4794,6 +5014,282 @@
             <inheritdoc />
         </member>
         <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="T:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1">
+            <summary>
+            Represents a drop zone container.
+            </summary>
+            <typeparam name="TItem">Type of the item.</typeparam>
+        </member>
+        <member name="F:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1._children">
+            <summary>
+            Represents the children inside the component.
+            </summary>
+        </member>
+        <member name="F:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1._renderItem">
+            <summary>
+            Represents the fragment to render an item.
+            </summary>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1"/>.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.State">
+            <summary>
+            Gets or sets the state of the component.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.ChildContent">
+            <summary>
+            Gets or sets the child content.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.Virtualize">
+            <summary>
+            Gets or sets if the component is virtualized.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.ItemSize">
+            <summary>
+            Gets or sets the size of the item.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.MaxItems">
+            <summary>
+            Gets or sets the maximum items which can be dragged.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.ItemKey">
+            <summary>
+            Gets or sets the function to extract a key from an item.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.Layout">
+            <summary>
+            Gets or sets the layout of the grid.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.InternalCss">
+            <summary>
+            Gets the css of the component.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.InternalStyle">
+            <summary>
+            Gets the style of the component.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.CanOverflow">
+            <summary>
+            Gets or sets a value indicating if the component can overflow.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.IsDropAllowed">
+            <summary>
+            Gets or sets a function which indicates if a component can be dropped.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.ItemContent">
+            <summary>
+            Gets or sets the content of an item.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.IsDragAllowed">
+            <summary>
+            Gets or sets a function which indicates if the component can be dragged.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.Immediate">
+            <summary>
+            Gets or sets a value indicating if the drag and drop is immediate.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.CloneItem">
+            <summary>
+            Gets or sets a function to clone an item.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.ItemCss">
+            <summary>
+            Gets or sets a function to set the css of an item.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.IsDragEnabled">
+            <summary>
+            Gets or sets if the drag is enabled.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.Items">
+            <summary>
+            Gets or sets the list of the items.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.Overflow">
+            <summary>
+            Gets or sets the event callback to raise when the component overflows.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.DragEnd">
+            <summary>
+            Gets or sets the event callback to raise when the drag ends.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.OnItemDropRejected">
+            <summary>
+            Gets or sets the event callback to raise when the drop is rejected for an item.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.OnItemDrop">
+            <summary>
+            Gets or sets the event callback to raise when an item is dropped.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.OnReplacedItemDrop">
+            <summary>
+            Gets or sets the event callback to raise when an item is replaced after drop.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.TileGridSettings">
+            <summary>
+            Gets or sets the settings of the tile grid.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.PersistenceEnabled">
+            <summary>
+            Gets or sets if the layout is persisted.
+            </summary>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.OnDropAsync(Microsoft.AspNetCore.Components.Web.DragEventArgs)">
+            <summary>
+            Occurs when an item is dropped into the component.
+            </summary>
+            <param name="e">Event args associated to the drop.</param>
+            <returns>Returns a task which manages the drop when completed.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.IsItemDraggable(`0)">
+            <summary>
+            Gets a value indicating if an item is draggable or not.
+            </summary>
+            <param name="item">Item to check.</param>
+            <returns>Returns <see langword="true" /> if the item is draggable, <see langword="false" /> otherwise.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.IsOverflow">
+            <summary>
+            Gets if the component overflows.
+            </summary>
+            <returns>Returns <see langword="true" /> if the component overflows, <see langword="false" /> otherwise.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.IsItemDropAllowed(`0)">
+            <summary>
+            Gets a value indicating if the item is allowed to drop.
+            </summary>
+            <param name="item">Item to check.</param>
+            <returns>Returns <see langword="true" /> if the item is allowed to drop, <see langword="false" /> otherwise.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.IndexOf(`0)">
+            <summary>
+            Gets the index of the item.
+            </summary>
+            <param name="item">Item to get the index.</param>
+            <returns>Returns the index of the item.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.RemoveAt(System.Int32)">
+            <summary>
+            Remove the item at the specified <paramref name="index"/>.
+            </summary>
+            <param name="index">Index of the item.</param>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.Insert(System.Int32,`0)">
+            <summary>
+            Inserts the item at the specified index.
+            </summary>
+            <param name="index">Index of the item.</param>
+            <param name="item">Item to insert.</param>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.IsDropAllowedAsync">
+            <summary>
+            Gets a value indicating if the drop is allowed.
+            </summary>
+            <returns>Returns a task which contains <see langword="true"/> if the drop is allowed, <see langword="false" /> otherwise
+             when completed.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.OnItemDropAsync(`0)">
+            <summary>
+            Drops an item in an asynchronous way.
+            </summary>
+            <param name="item">Item to drop.</param>
+            <returns>Returns a task which drops an item when completed.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.OnDragEndAsync">
+            <summary>
+            Finish the drag.
+            </summary>
+            <returns>Returns a task which completes the drag when completed.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.UpdateItems">
+            <summary>
+            Updates the items.
+            </summary>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.Add(Microsoft.FluentUI.AspNetCore.Components.FluentComponentBase)">
+            <summary>
+            Adds a child into the container.
+            </summary>
+            <param name="child">Child to add.</param>
+            <exception cref="T:System.InvalidOperationException">Occurs when the child is not <see cref="T:FluentUI.Blazor.Community.Components.IItemValue`1"/> and
+             when the value of the child is <see langword="null" /></exception>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.Remove(Microsoft.FluentUI.AspNetCore.Components.FluentComponentBase)">
+            <summary>
+            Removes a child from the container.
+            </summary>
+            <param name="child">Child to remove.</param>
+            <exception cref="T:System.InvalidOperationException">Occurs when the child is not <see cref="T:FluentUI.Blazor.Community.Components.IItemValue`1"/> and
+             when the value of the child is <see langword="null" /></exception>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.SwapAsync(`0,`0)">
+            <summary>
+            Swap the <paramref name="overItem"/> with the <paramref name="activeItem"/>.
+            </summary>
+            <param name="overItem">First item to swap.</param>
+            <param name="activeItem">Second item to swap.</param>
+            <returns>Returns a task which swap the items when completed.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.Refresh">
+            <summary>
+            Refresh the component.
+            </summary>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.OnDropItemPlaceholderAsync(System.Int32)">
+            <summary>
+            Drops the item inside a placeholder in an asynchronous way.
+            </summary>
+            <param name="index">Index of the placeholder.</param>
+            <returns>Returns a task which drops the item in the placeholder when completed.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.GetStyle(`0)">
+            <summary>
+            Gets the style of the <paramref name="value"/>.
+            </summary>
+            <param name="value">Value to get the style.</param>
+            <returns>Returns the style of the item.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.ReorderItemsFromLayout">
+            <summary>
+            Reorders the items using a layout.
+            </summary>
+            <returns>Returns the ordered items.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.ReorderChildrenFromLayout">
+            <summary>
+            Reorders the children using a layout.
+            </summary>
+            <returns>Returns the ordered components.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZoneContainer`1.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder)">
             <inheritdoc />
         </member>
         <member name="T:FluentUI.Blazor.Community.Components.Internal.TileGridSettings">
@@ -5070,6 +5566,21 @@
             </summary>
             <typeparam name="TItem">Type of the component.</typeparam>
         </member>
+        <member name="F:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1._layout">
+            <summary>
+            Represents the layout of the tile grid.
+            </summary>
+        </member>
+        <member name="F:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1.JavascriptFile">
+            <summary>
+            Represents the javascript file to use to load and to store the layout.
+            </summary>
+        </member>
+        <member name="F:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1._module">
+            <summary>
+            Represents the reference of the javascript object. 
+            </summary>
+        </member>
         <member name="M:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1.#ctor">
             <summary>
             Initializes a new instance of the <see cref="T:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1"/> component.
@@ -5179,7 +5690,63 @@
             Gets or sets the height of the grid.
             </summary>
         </member>
+        <member name="P:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1.PersistenceEnabled">
+            <summary>
+            Gets or sets a value indicating if the layout will be stored in the local storage of the app or not.
+            </summary>
+            <remarks>
+            When this value is set to <see langword="true" />, the <see cref="P:Microsoft.FluentUI.AspNetCore.Components.FluentComponentBase.Id"/> property must be set
+             and mustn't change.</remarks>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1.ItemKey">
+            <summary>
+            Gets or sets the function to extract a key from an item.
+            </summary>
+            <remarks>This function is only used if <see cref="P:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1.PersistenceEnabled"/> is set to <see langword="true" />.</remarks>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1.OnSaveRequested(System.Object,System.EventArgs)">
+            <summary>
+            Occurs when a save is requested.
+            </summary>
+            <param name="sender">Object who invokes the method.</param>
+            <param name="e">Event args associated to this event.</param>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1.AddLayoutItem(FluentUI.Blazor.Community.Components.FluentCxTileGridItem{`0},System.Nullable{System.Int32})">
+            <summary>
+            Adds a layout item.
+            </summary>
+            <param name="value">Item to add.</param>
+            <param name="index">Index of the item.</param>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1.RemoveLayoutItem(System.Nullable{System.Int32})">
+            <summary>
+            Remove a layout item.
+            </summary>
+            <param name="index">Index of the item to remove.</param>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1.UpdateLayoutAsync(FluentUI.Blazor.Community.Components.FluentCxTileGridItem{`0})">
+            <summary>
+            Update the layout in an asynchronous way.
+            </summary>
+            <param name="value">Item to update.</param>
+            <returns></returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1.SaveLayoutAsync">
+            <summary>
+            Save the layout in an asynchronous way.
+            </summary>
+            <returns>Returns a task which saves the layout when completed.</returns>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1.OnParametersSet">
+            <inheritdoc />
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1.OnAfterRenderAsync(System.Boolean)">
+            <inheritdoc />
+        </member>
         <member name="M:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1.BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder)">
+            <inheritdoc />
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1.Dispose">
             <inheritdoc />
         </member>
         <member name="T:FluentUI.Blazor.Community.Components.FluentCxTileGridItem`1">
@@ -5228,10 +5795,23 @@
             Gets or sets the parent of the component.
             </summary>
         </member>
+        <member name="M:FluentUI.Blazor.Community.Components.FluentCxTileGridItem`1.OnResizedAsync(FluentUI.Blazor.Community.Components.ResizedEventArgs)">
+            <summary>
+            Occurs when the tile is resized in an asynchronous way.
+            </summary>
+            <param name="e">Event args which contains the new size of the tile.</param>
+            <returns>Returns a task which resizes the tile when completed.</returns>
+        </member>
         <member name="M:FluentUI.Blazor.Community.Components.FluentCxTileGridItem`1.Dispose">
             <inheritdoc />
         </member>
         <member name="M:FluentUI.Blazor.Community.Components.FluentCxTileGridItem`1.OnInitialized">
+            <inheritdoc />
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.FluentCxTileGridItem`1.OnInitializedAsync">
+            <inheritdoc />
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.FluentCxTileGridItem`1.SetSpan(System.Int32,System.Int32)">
             <inheritdoc />
         </member>
         <member name="T:FluentUI.Blazor.Community.Components.IDropZoneComponent`1">
@@ -5239,11 +5819,6 @@
             Represents an interface for the <see cref="T:FluentUI.Blazor.Community.Components.Internal.FluentCxDropZone`1"/> component.
             </summary>
             <typeparam name="TItem"></typeparam>
-        </member>
-        <member name="P:FluentUI.Blazor.Community.Components.IDropZoneComponent`1.Value">
-            <summary>
-            Gets the value of the drop zone.
-            </summary>
         </member>
         <member name="P:FluentUI.Blazor.Community.Components.IDropZoneComponent`1.Id">
             <summary>
@@ -5281,6 +5856,41 @@
         <member name="P:FluentUI.Blazor.Community.Components.ITileGridItemDropZoneComponent`1.RowSpan">
             <summary>
             Gets the row span of the <see cref="T:FluentUI.Blazor.Community.Components.FluentCxTileGridItem`1"/>.
+            </summary>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.ITileGridItemDropZoneComponent`1.SetSpan(System.Int32,System.Int32)">
+            <summary>
+            Sets the span of the item.
+            </summary>
+            <param name="columnSpan">Column span of the item.</param>
+            <param name="rowSpan">Row span of the item.</param>
+        </member>
+        <member name="T:FluentUI.Blazor.Community.Components.TileGridLayout">
+            <summary>
+            Represents the layout of the <see cref="T:FluentUI.Blazor.Community.Components.FluentCxTileGrid`1"/>
+            </summary>
+        </member>
+        <member name="M:FluentUI.Blazor.Community.Components.TileGridLayout.UpdateSpan(System.String,System.Int32,System.Int32)">
+            <summary>
+            Updates the span of the item.
+            </summary>
+            <param name="key">Key of the item.</param>
+            <param name="columnSpan">Column span of the item.</param>
+            <param name="rowSpan">Row span of the item.</param>
+        </member>
+        <member name="T:FluentUI.Blazor.Community.Components.TileGridLayoutItem">
+            <summary>
+            Represents an item for the <see cref="T:FluentUI.Blazor.Community.Components.TileGridLayout"/>.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.TileGridLayoutItem.ColumnSpan">
+            <summary>
+            Gets or sets the column span of the item.
+            </summary>
+        </member>
+        <member name="P:FluentUI.Blazor.Community.Components.TileGridLayoutItem.RowSpan">
+            <summary>
+            Gets or sets the row span of the item.
             </summary>
         </member>
         <member name="T:FluentUI.Blazor.Community.Extensions.ParameterViewExtensions">

--- a/examples/demo/FluentUI.Demo.Shared/Pages/TileGrid/Examples/TileGridDashboard.razor
+++ b/examples/demo/FluentUI.Demo.Shared/Pages/TileGrid/Examples/TileGridDashboard.razor
@@ -7,6 +7,9 @@
                       RowHeight="200px"
                       CanResize
                       CanReorder
+                      PersistenceEnabled
+                      ItemKey=@(e => e.Header)
+                      Id="Dashboard"
                       TItem="DashboardItem">
         <FluentCxTileGridItem Value="@Item1">
                 @renderCard(Item1)
@@ -123,19 +126,19 @@
 
     private DashboardItem Item5 = new()
     {
-        Header = "Number of user",
+        Header = "Number of products",
         Data = 123
     };
 
     private DashboardItem Item6 = new()
     {
-        Header = "Number of user",
+        Header = "Number of new subscribers per month",
         Data = 123
     };
 
     private DashboardItem Item7 = new()
     {
-        Header = "Number of user",
+        Header = "Number of new products per month",
         Data = 123
     };
 }

--- a/src/Community.Components/Components/GridLayoutBase.cs
+++ b/src/Community.Components/Components/GridLayoutBase.cs
@@ -1,0 +1,134 @@
+using System.Collections;
+using System.Text.Json.Serialization;
+
+namespace FluentUI.Blazor.Community.Components;
+
+/// <summary>
+/// Represents a base for a grid layout.
+/// </summary>
+[JsonDerivedType(typeof(TileGridLayout))]
+public abstract class GridLayoutBase
+    : IEnumerable<GridLayoutBaseItem>
+{
+    /// <summary>
+    /// Represents the items inside the layout.
+    /// </summary>
+    private readonly List<GridLayoutBaseItem> _items = [];
+
+    /// <summary>
+    /// Gets the items inside the layout.
+    /// </summary>
+    public IEnumerable<GridLayoutBaseItem> Items => _items;
+
+    /// <summary>
+    /// Event to invoke when a save is requested.
+    /// </summary>
+    internal event EventHandler? SaveRequested;
+
+    /// <summary>
+    /// Gets or sets a value indicating is dirty or not.
+    /// </summary>
+    internal bool IsDirty { get; set; }
+
+    /// <summary>
+    /// Gets the item from its key.
+    /// </summary>
+    /// <typeparam name="T">Type of the item.</typeparam>
+    /// <param name="key">Key to find.</param>
+    /// <returns>Returns the item if found, <see langword="false" /> otherwise.</returns>
+    protected T? Get<T>(string? key) where T : GridLayoutBaseItem
+    {
+        return _items.Find(x => string.Equals(x.Key, key, StringComparison.OrdinalIgnoreCase)) as T;
+    }
+
+    /// <summary>
+    /// Adds a range of <paramref name="items"/> into the layout.
+    /// </summary>
+    /// <param name="items">Items to add.</param>
+    internal void AddRange(IEnumerable<GridLayoutBaseItem> items)
+    {
+        if (items is not null &&
+            items.Any() &&
+            _items.Count > 0)
+        {
+            _items.Clear();
+            _items.AddRange(items);
+        }
+    }
+
+    /// <summary>
+    /// Adds an item into the layout.
+    /// </summary>
+    /// <typeparam name="T">Type of the item.</typeparam>
+    /// <param name="key">Key of the item.</param>
+    /// <param name="index">Index of the item.</param>
+    internal void Add<T>(string key, int index) where T : GridLayoutBaseItem, new()
+    {
+        _items.Add(new T()
+        {
+            Index = index,
+            Key = key
+        });
+    }
+
+    /// <summary>
+    /// Removes an item from its index.
+    /// </summary>
+    /// <param name="index">Index to remove.</param>
+    internal void Remove(int index)
+    {
+        var item = _items.Find(x => x.Index == index);
+
+        if (item is not null)
+        {
+            _items.Remove(item);
+        }
+    }
+
+    /// <inheritdoc />
+    public IEnumerator<GridLayoutBaseItem> GetEnumerator()
+    {
+        return _items.GetEnumerator();
+    }
+
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+
+    /// <summary>
+    /// Request a save.
+    /// </summary>
+    internal void RequestSave()
+    {
+        SaveRequested?.Invoke(this, EventArgs.Empty);
+        IsDirty = false;
+    }
+
+    /// <summary>
+    /// Updates the items.
+    /// </summary>
+    /// <typeparam name="TItem">Type of the items.</typeparam>
+    /// <param name="keyFunc">Function to extract a key from an item.</param>
+    /// <param name="items">Items to rearrange.</param>
+    /// <exception cref="InvalidOperationException">Occurs when <paramref name="keyFunc"/> is
+    ///  <see langword="null" />.</exception>
+    internal void Update<TItem>(Func<TItem, string>? keyFunc, IList<TItem> items)
+    {
+        if (keyFunc is null)
+        {
+            throw new InvalidOperationException("The keyFunc cannot be null.");
+        }
+
+        for (var i = 0; i < items.Count; ++i)
+        {
+            var layoutItem = _items.Find(x => string.Equals(x.Key, keyFunc(items[i]), StringComparison.OrdinalIgnoreCase));
+
+            if (layoutItem is not null)
+            {
+                layoutItem.Index = i;
+            }
+        }
+    }
+}

--- a/src/Community.Components/Components/GridLayoutBaseItem.cs
+++ b/src/Community.Components/Components/GridLayoutBaseItem.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace FluentUI.Blazor.Community.Components;
+
+/// <summary>
+/// Represents an item of a <see cref="GridLayoutBase"/>.
+/// </summary>
+[JsonDerivedType(typeof(TileGridLayoutItem))]
+public class GridLayoutBaseItem
+{
+    /// <summary>
+    /// Gets or sets the index of the item.
+    /// </summary>
+    public int Index {  get; set; }
+
+    /// <summary>
+    /// Gets or sets the key of the item.
+    /// </summary>
+    public string? Key {  get; set; }
+}

--- a/src/Community.Components/Components/Internal/DropZone/FluentCxDropZone.cs
+++ b/src/Community.Components/Components/Internal/DropZone/FluentCxDropZone.cs
@@ -7,12 +7,26 @@ using Microsoft.FluentUI.AspNetCore.Components.Utilities;
 
 namespace FluentUI.Blazor.Community.Components.Internal;
 
+/// <summary>
+/// Represents the drop zone component.
+/// </summary>
+/// <typeparam name="TItem">Type of the item.</typeparam>
 internal class FluentCxDropZone<TItem>
     : FluentComponentBase, IDisposable, IItemValue<TItem>
 {
+    /// <summary>
+    /// Represents the fragment to render the drop zone.
+    /// </summary>
     internal readonly RenderFragment _renderDropZone;
+
+    /// <summary>
+    /// Represents a value indicating if the cursor enters into the component.
+    /// </summary>
     private bool _dragEnter;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FluentCxDropZone{TItem}"/>.
+    /// </summary>
     public FluentCxDropZone()
     {
         Id = Identifier.NewId();
@@ -87,23 +101,44 @@ internal class FluentCxDropZone<TItem>
         };
     }
 
+    /// <summary>
+    /// Gets or sets the parent component.
+    /// </summary>
     [CascadingParameter]
     private FluentCxDropZoneContainer<TItem> DropZoneContainer { get; set; } = default!;
 
+    /// <summary>
+    /// Gets or sets the child content.
+    /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
+    /// <summary>
+    /// Gets or sets the css for the item.
+    /// </summary>
     [Parameter]
     public string? ItemCss { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating if the component can be dragged.
+    /// </summary>
     [Parameter]
     public bool IsDragAllowed { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating if the component can be dropped.
+    /// </summary>
     [Parameter]
     public bool IsItemDropAllowed { get; set; }
 
+    /// <summary>
+    /// Gets the state of the parent container.
+    /// </summary>
     private DropZoneState<TItem> State => DropZoneContainer.State;
 
+    /// <summary>
+    /// Gets or sets the value of the component.
+    /// </summary>
     [Parameter]
     public TItem? Value { get; set; }
 
@@ -127,10 +162,20 @@ internal class FluentCxDropZone<TItem>
     [Parameter]
     public bool AddInContainer { get; set; } = true;
 
+    /// <summary>
+    /// Gets the index of the current component inside the container.
+    /// </summary>
     private int Index => DropZoneContainer?.IndexOf(Value) ?? -1;
 
+    /// <summary>
+    /// Gets the render of the current component.
+    /// </summary>
     public RenderFragment? Component => _renderDropZone;
 
+    /// <summary>
+    /// Gets the style of the item.
+    /// </summary>
+    /// <returns>Returns the style of the item.</returns>
     private string? GetItemStyle()
     {
         var style = new StyleBuilder(Style)
@@ -140,6 +185,10 @@ internal class FluentCxDropZone<TItem>
         return style.Build();
     }
 
+    /// <summary>
+    /// Gets the css of the item.
+    /// </summary>
+    /// <returns>Returns the css of the item.</returns>
     private string? GetItemCss()
     {
         var css = new CssBuilder()
@@ -159,6 +208,10 @@ internal class FluentCxDropZone<TItem>
         return css.Build();
     }
 
+    /// <summary>
+    /// Gets the value indicating if the target is not allowed to be dragged.
+    /// </summary>
+    /// <returns>Returns <see langword="true" /> if the target cannot be dragged, <see langword="false" /> otherwise.</returns>
     private bool GetIsDragTargetDenied()
     {
         if (Value?.Equals(State.ActiveItem) ?? false)
@@ -174,6 +227,10 @@ internal class FluentCxDropZone<TItem>
         return false;
     }
 
+    /// <summary>
+    /// Gets a value indicating if the target can be dragged.
+    /// </summary>
+    /// <returns>Returns <see langword="true" /> if the target can be dragged, <see langword="false" /> otherwise.</returns>
     private bool GetIsDragTarget()
     {
         if (Value?.Equals(State.ActiveItem) ?? false)
@@ -189,6 +246,11 @@ internal class FluentCxDropZone<TItem>
         return false;
     }
 
+    /// <summary>
+    /// Gets the css for the placeholder.
+    /// </summary>
+    /// <param name="index">Index of the placeholder.</param>
+    /// <returns>Returns the css of the placeholder.</returns>
     private string? GetPlaceholderCss(int index)
     {
         return new CssBuilder()
@@ -199,6 +261,9 @@ internal class FluentCxDropZone<TItem>
                 .Build();
     }
 
+    /// <summary>
+    /// Occurs when the component leaves a drop zone.
+    /// </summary>
     private void OnDragLeave()
     {
         _dragEnter = false;
@@ -206,25 +271,46 @@ internal class FluentCxDropZone<TItem>
         DropZoneContainer.Refresh();
     }
 
+    /// <summary>
+    /// Occurs when the user has finished dragging the component.
+    /// </summary>
+    /// <returns>Returns a task which completes the drag.</returns>
     private async Task OnDragEndAsync()
     {
         await DropZoneContainer.OnDragEndAsync();
         await InvokeAsync(DropZoneContainer.Refresh);
     }
 
+    /// <summary>
+    /// Occurs when the components drops into a valid placeholder.
+    /// </summary>
+    /// <param name="index">Index of the placeholder.</param>
+    /// <returns>Returns a task which process the placeholder when completed.</returns>
     private async Task OnDropItemOnPlaceholderAsync(int index)
     {
         await DropZoneContainer.OnDropItemPlaceholderAsync(index);
     }
 
+    /// <summary>
+    /// Occurs when the drag starts.
+    /// </summary>
     private void OnDragStart()
     {
+        if (DropZoneContainer?.Layout is not null)
+        {
+            DropZoneContainer.Layout.IsDirty = true;
+        }
+
         State.ActiveItem = Value;
         DropZoneContainer?.UpdateItems();
         DropZoneContainer?.Refresh();
         StateHasChanged();
     }
 
+    /// <summary>
+    /// Occurs when the component enters a valid drop zone.
+    /// </summary>
+    /// <returns>Returns a task which swap the components when completed.</returns>
     private async Task OnDragEnterAsync()
     {
         if (_dragEnter)
@@ -265,6 +351,15 @@ internal class FluentCxDropZone<TItem>
         await InvokeAsync(DropZoneContainer.Refresh);
     }
 
+    /// <summary>
+    /// Force the rendering of the component.
+    /// </summary>
+    internal void RenderInternal()
+    {
+        ForceRender = true;
+        StateHasChanged();
+    }
+
     /// <inheritdoc />
     protected override void OnInitialized()
     {
@@ -285,12 +380,6 @@ internal class FluentCxDropZone<TItem>
         }
 
         GC.SuppressFinalize(this);
-    }
-
-    internal void RenderInternal()
-    {
-        ForceRender = true;
-        StateHasChanged();
     }
 
     /// <inheritdoc />

--- a/src/Community.Components/Components/Internal/DropZone/FluentCxDropZoneContainer.cs
+++ b/src/Community.Components/Components/Internal/DropZone/FluentCxDropZoneContainer.cs
@@ -1,27 +1,41 @@
 using FluentUI.Blazor.Community.Extensions;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.CompilerServices;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.Web.Virtualization;
 using Microsoft.FluentUI.AspNetCore.Components;
 using Microsoft.FluentUI.AspNetCore.Components.Utilities;
-using Microsoft.AspNetCore.Components.CompilerServices;
-using Microsoft.AspNetCore.Components.Web.Virtualization;
 
 namespace FluentUI.Blazor.Community.Components.Internal;
 
+/// <summary>
+/// Represents a drop zone container.
+/// </summary>
+/// <typeparam name="TItem">Type of the item.</typeparam>
 [CascadingTypeParameter(nameof(TItem))]
 internal sealed class FluentCxDropZoneContainer<TItem>
     : FluentComponentBase
 {
     #region Fields
 
+    /// <summary>
+    /// Represents the children inside the component.
+    /// </summary>
     private readonly List<FluentComponentBase> _children = [];
+
+    /// <summary>
+    /// Represents the fragment to render an item.
+    /// </summary>
     private readonly RenderFragment<TItem> _renderItem;
 
     #endregion Fields
 
     #region Constructors
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FluentCxDropZoneContainer{TItem}"/>.
+    /// </summary>
     public FluentCxDropZoneContainer()
     {
         _renderItem = value => __builder =>
@@ -43,10 +57,20 @@ internal sealed class FluentCxDropZoneContainer<TItem>
                 }
                 else
                 {
-                    var content = _children.Find(x => x is IItemValue<TItem> t && Equals(t.Value, value));
+                    var content = _children.Find(x => x is IItemValue<TItem> t && string.Equals(ItemKey!(t.Value!), ItemKey(value)));
 
                     if (content is not null && content is IDropZoneComponent<TItem> t)
                     {
+                        if (t is ITileGridItemDropZoneComponent<TItem> k)
+                        {
+                            var item = Layout?.Items.FirstOrDefault(x => x.Key == ItemKey!(t.Value!));
+
+                            if (item is TileGridLayoutItem layoutItem)
+                            {
+                                k.SetSpan(layoutItem.ColumnSpan, layoutItem.RowSpan);
+                            }
+                        }
+
                         __builder2.AddContent(43, t.Component);
                     }
                 }
@@ -61,80 +85,169 @@ internal sealed class FluentCxDropZoneContainer<TItem>
 
     #region Properties
 
+    /// <summary>
+    /// Gets or sets the state of the component.
+    /// </summary>
     [Inject]
     public required DropZoneState<TItem> State { get; set; }
 
+    /// <summary>
+    /// Gets or sets the child content.
+    /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
+    /// <summary>
+    /// Gets or sets if the component is virtualized.
+    /// </summary>
     [Parameter]
     public bool Virtualize { get; set; }
 
+    /// <summary>
+    /// Gets or sets the size of the item.
+    /// </summary>
     [Parameter]
     public float ItemSize { get; set; } = 50f;
 
+    /// <summary>
+    /// Gets or sets the maximum items which can be dragged.
+    /// </summary>
     [Parameter]
     public int? MaxItems { get; set; }
 
+    /// <summary>
+    /// Gets or sets the function to extract a key from an item.
+    /// </summary>
+    [Parameter]
+    public Func<TItem, string>? ItemKey { get; set; }
+
+    /// <summary>
+    /// Gets or sets the layout of the grid.
+    /// </summary>
+    [Parameter]
+    public GridLayoutBase? Layout { get; set; }
+
+    /// <summary>
+    /// Gets the css of the component.
+    /// </summary>
     private string? InternalCss => new CssBuilder()
         .AddClass(Class)
         .AddClass("fluentcx-drop-zone")
         .Build();
 
+    /// <summary>
+    /// Gets the style of the component.
+    /// </summary>
     private string? InternalStyle => new StyleBuilder(Style)
         .AddStyle(TileGridSettings?.ToString())
         .AddStyle("overflow-y", "auto", CanOverflow)
         .Build();
 
+    /// <summary>
+    /// Gets or sets a value indicating if the component can overflow.
+    /// </summary>
     [Parameter]
     public bool CanOverflow { get; set; }
 
+    /// <summary>
+    /// Gets or sets a function which indicates if a component can be dropped.
+    /// </summary>
     [Parameter]
     public Func<TItem?, TItem?, bool>? IsDropAllowed { get; set; }
 
+    /// <summary>
+    /// Gets or sets the content of an item.
+    /// </summary>
     [Parameter]
     public RenderFragment<TItem>? ItemContent { get; set; }
 
+    /// <summary>
+    /// Gets or sets a function which indicates if the component can be dragged.
+    /// </summary>
     [Parameter]
     public Func<TItem, bool>? IsDragAllowed { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating if the drag and drop is immediate.
+    /// </summary>
     [Parameter]
     public bool Immediate { get; set; }
 
+    /// <summary>
+    /// Gets or sets a function to clone an item.
+    /// </summary>
     [Parameter]
     public Func<TItem, TItem>? CloneItem { get; set; }
 
+    /// <summary>
+    /// Gets or sets a function to set the css of an item.
+    /// </summary>
     [Parameter]
     public Func<TItem, string>? ItemCss { get; set; }
 
+    /// <summary>
+    /// Gets or sets if the drag is enabled.
+    /// </summary>
     [Parameter]
     public bool IsDragEnabled { get; set; } = true;
 
+    /// <summary>
+    /// Gets or sets the list of the items.
+    /// </summary>
     [Parameter]
     public IList<TItem> Items { get; set; } = [];
 
+    /// <summary>
+    /// Gets or sets the event callback to raise when the component overflows.
+    /// </summary>
     [Parameter]
     public EventCallback<TItem> Overflow { get; set; }
 
+    /// <summary>
+    /// Gets or sets the event callback to raise when the drag ends.
+    /// </summary>
     [Parameter]
     public EventCallback<TItem> DragEnd { get; set; }
 
+    /// <summary>
+    /// Gets or sets the event callback to raise when the drop is rejected for an item.
+    /// </summary>
     [Parameter]
     public EventCallback<TItem> OnItemDropRejected { get; set; }
 
+    /// <summary>
+    /// Gets or sets the event callback to raise when an item is dropped.
+    /// </summary>
     [Parameter]
     public EventCallback<TItem> OnItemDrop { get; set; }
 
+    /// <summary>
+    /// Gets or sets the event callback to raise when an item is replaced after drop.
+    /// </summary>
     [Parameter]
     public EventCallback<TItem> OnReplacedItemDrop { get; set; }
 
+    /// <summary>
+    /// Gets or sets the settings of the tile grid.
+    /// </summary>
     [Parameter]
     public ITileGridSettings? TileGridSettings { get; set; }
+
+    /// <summary>
+    /// Gets or sets if the layout is persisted.
+    /// </summary>
+    [Parameter]
+    public bool PersistenceEnabled { get; set; }
 
     #endregion Properties
 
     #region Methods
 
+    /// <summary>
+    /// Occurs when an item is dropped into the component.
+    /// </summary>
+    /// <param name="e">Event args associated to the drop.</param>
+    /// <returns>Returns a task which manages the drop when completed.</returns>
     private async Task OnDropAsync(DragEventArgs e)
     {
         if (!await IsDropAllowedAsync())
@@ -184,9 +297,17 @@ internal sealed class FluentCxDropZoneContainer<TItem>
 
         State.Reset();
         await OnItemDrop.InvokeAsync(activeItem);
+
+        Layout?.Update(ItemKey, Items);
+        Layout?.RequestSave();
         await InvokeAsync(StateHasChanged);
     }
 
+    /// <summary>
+    /// Gets a value indicating if an item is draggable or not.
+    /// </summary>
+    /// <param name="item">Item to check.</param>
+    /// <returns>Returns <see langword="true" /> if the item is draggable, <see langword="false" /> otherwise.</returns>
     private bool IsItemDraggable(TItem? item)
     {
         if (!IsDragEnabled)
@@ -207,6 +328,10 @@ internal sealed class FluentCxDropZoneContainer<TItem>
         return IsDragAllowed(item);
     }
 
+    /// <summary>
+    /// Gets if the component overflows.
+    /// </summary>
+    /// <returns>Returns <see langword="true" /> if the component overflows, <see langword="false" /> otherwise.</returns>
     internal bool IsOverflow()
     {
         var activeItem = State.ActiveItem;
@@ -219,6 +344,11 @@ internal sealed class FluentCxDropZoneContainer<TItem>
         return (!Items.Contains(activeItem) && MaxItems.HasValue && MaxItems == Items.Count);
     }
 
+    /// <summary>
+    /// Gets a value indicating if the item is allowed to drop.
+    /// </summary>
+    /// <param name="item">Item to check.</param>
+    /// <returns>Returns <see langword="true" /> if the item is allowed to drop, <see langword="false" /> otherwise.</returns>
     internal bool IsItemDropAllowed(TItem? item)
     {
         if (IsDropAllowed is null)
@@ -229,6 +359,11 @@ internal sealed class FluentCxDropZoneContainer<TItem>
         return IsDropAllowed(State.ActiveItem, item);
     }
 
+    /// <summary>
+    /// Gets the index of the item.
+    /// </summary>
+    /// <param name="item">Item to get the index.</param>
+    /// <returns>Returns the index of the item.</returns>
     internal int IndexOf(TItem? item)
     {
         if (item is null)
@@ -244,16 +379,30 @@ internal sealed class FluentCxDropZoneContainer<TItem>
         return Items.IndexOf(item);
     }
 
+    /// <summary>
+    /// Remove the item at the specified <paramref name="index"/>.
+    /// </summary>
+    /// <param name="index">Index of the item.</param>
     internal void RemoveAt(int index)
     {
         Items?.RemoveAt(index);
     }
 
+    /// <summary>
+    /// Inserts the item at the specified index.
+    /// </summary>
+    /// <param name="index">Index of the item.</param>
+    /// <param name="item">Item to insert.</param>
     internal void Insert(int index, TItem item)
     {
         Items?.Insert(index, item);
     }
 
+    /// <summary>
+    /// Gets a value indicating if the drop is allowed.
+    /// </summary>
+    /// <returns>Returns a task which contains <see langword="true"/> if the drop is allowed, <see langword="false" /> otherwise
+    ///  when completed.</returns>
     internal async Task<bool> IsDropAllowedAsync()
     {
         var activeItem = State.ActiveItem;
@@ -286,6 +435,11 @@ internal sealed class FluentCxDropZoneContainer<TItem>
         return true;
     }
 
+    /// <summary>
+    /// Drops an item in an asynchronous way.
+    /// </summary>
+    /// <param name="item">Item to drop.</param>
+    /// <returns>Returns a task which drops an item when completed.</returns>
     internal async Task OnItemDropAsync(TItem? item)
     {
         if (OnItemDrop.HasDelegate &&
@@ -297,6 +451,10 @@ internal sealed class FluentCxDropZoneContainer<TItem>
         await InvokeAsync(StateHasChanged);
     }
 
+    /// <summary>
+    /// Finish the drag.
+    /// </summary>
+    /// <returns>Returns a task which completes the drag when completed.</returns>
     internal async Task OnDragEndAsync()
     {
         if (DragEnd.HasDelegate)
@@ -308,11 +466,20 @@ internal sealed class FluentCxDropZoneContainer<TItem>
         await InvokeAsync(StateHasChanged);
     }
 
+    /// <summary>
+    /// Updates the items.
+    /// </summary>
     internal void UpdateItems()
     {
         State.Items = Items;
     }
 
+    /// <summary>
+    /// Adds a child into the container.
+    /// </summary>
+    /// <param name="child">Child to add.</param>
+    /// <exception cref="InvalidOperationException">Occurs when the child is not <see cref="IItemValue{TItem}"/> and
+    ///  when the value of the child is <see langword="null" /></exception>
     internal void Add(FluentComponentBase child)
     {
         if (child is not IItemValue<TItem> t)
@@ -333,6 +500,12 @@ internal sealed class FluentCxDropZoneContainer<TItem>
         }
     }
 
+    /// <summary>
+    /// Removes a child from the container.
+    /// </summary>
+    /// <param name="child">Child to remove.</param>
+    /// <exception cref="InvalidOperationException">Occurs when the child is not <see cref="IItemValue{TItem}"/> and
+    ///  when the value of the child is <see langword="null" /></exception>
     internal void Remove(FluentComponentBase child)
     {
         if (child is not IItemValue<TItem> t)
@@ -350,6 +523,12 @@ internal sealed class FluentCxDropZoneContainer<TItem>
         StateHasChanged();
     }
 
+    /// <summary>
+    /// Swap the <paramref name="overItem"/> with the <paramref name="activeItem"/>.
+    /// </summary>
+    /// <param name="overItem">First item to swap.</param>
+    /// <param name="activeItem">Second item to swap.</param>
+    /// <returns>Returns a task which swap the items when completed.</returns>
     internal async Task SwapAsync(TItem? overItem, TItem? activeItem)
     {
         if (overItem is null || activeItem is null)
@@ -398,22 +577,24 @@ internal sealed class FluentCxDropZoneContainer<TItem>
         }
     }
 
+    /// <summary>
+    /// Refresh the component.
+    /// </summary>
     internal void Refresh()
     {
         if (ChildContent is not null)
         {
-            for (var i = 0; i < Items.Count; ++i)
-            {
-                var index = _children.FindIndex(x => x is IItemValue<TItem> t && Equals(t.Value, Items[i]));
-                var temp = _children[index];
-                _children.RemoveAt(index);
-                _children.Insert(i, temp);
-            }
+            ReorderChildrenFromLayout();
         }
 
         StateHasChanged();
     }
 
+    /// <summary>
+    /// Drops the item inside a placeholder in an asynchronous way.
+    /// </summary>
+    /// <param name="index">Index of the placeholder.</param>
+    /// <returns>Returns a task which drops the item in the placeholder when completed.</returns>
     internal async Task OnDropItemPlaceholderAsync(int index)
     {
         if (!await IsDropAllowedAsync())
@@ -464,6 +645,11 @@ internal sealed class FluentCxDropZoneContainer<TItem>
         await OnItemDropAsync(activeItem);
     }
 
+    /// <summary>
+    /// Gets the style of the <paramref name="value"/>.
+    /// </summary>
+    /// <param name="value">Value to get the style.</param>
+    /// <returns>Returns the style of the item.</returns>
     internal string? GetStyle(TItem? value)
     {
         if (_children.Count == 0 || value is null)
@@ -486,6 +672,83 @@ internal sealed class FluentCxDropZoneContainer<TItem>
         return null;
     }
 
+    /// <summary>
+    /// Reorders the items using a layout.
+    /// </summary>
+    /// <returns>Returns the ordered items.</returns>
+    private IEnumerable<TItem> ReorderItemsFromLayout()
+    {
+        if (Layout is null || !Layout.Items.Any() || Layout.IsDirty || ItemKey is null)
+        {
+            return Items;
+        }
+
+        SortedList<int, TItem> ordered = [];
+
+        foreach (var layoutItem in Layout)
+        {
+            var item = Items.FirstOrDefault(x => string.Equals(ItemKey(x), layoutItem.Key, StringComparison.OrdinalIgnoreCase));
+
+            if (item is not null)
+            {
+                ordered.Add(layoutItem.Index, item);
+            }
+        }
+
+        return ordered.Values;
+    }
+
+    /// <summary>
+    /// Reorders the children using a layout.
+    /// </summary>
+    /// <returns>Returns the ordered components.</returns>
+    private IList<FluentComponentBase> ReorderChildrenFromLayout()
+    {
+        if (Layout is null || !Layout.Items.Any() || Layout.IsDirty || ItemKey is null)
+        {
+            return _children;
+        }
+
+        var sortedList = new SortedList<int, FluentComponentBase>();
+        var sortedItems =new SortedList<int, TItem>();
+
+        foreach (var layoutItem in Layout)
+        {
+            var item = _children.Find(x => x is IItemValue<TItem> t && t.Value is not null && string.Equals(ItemKey(t.Value), layoutItem.Key, StringComparison.OrdinalIgnoreCase));
+
+            if (item is not null)
+            {
+                if (item is FluentCxTileGridItem<TItem> tg &&
+                    layoutItem is TileGridLayoutItem tgli)
+                {
+                    tg.SetSpan(tgli.ColumnSpan, tgli.RowSpan);
+                }
+
+                sortedList.Add(layoutItem.Index, item);
+            }
+
+            var orderedItem = Items.FirstOrDefault(x => string.Equals(ItemKey(x), layoutItem.Key, StringComparison.OrdinalIgnoreCase));
+
+            if (orderedItem is not null)
+            {
+                sortedItems.Add(layoutItem.Index, orderedItem);
+            }
+        }
+
+        Items.Clear();
+
+        foreach (var item in sortedItems)
+        {
+            Items.Add(item.Value);
+        }
+
+        _children.Clear();
+        _children.AddRange(sortedList.Values);
+
+        return _children;
+    }
+
+    /// <inheritdoc />
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
         base.BuildRenderTree(builder);
@@ -519,31 +782,29 @@ internal sealed class FluentCxDropZoneContainer<TItem>
             {
                 builder2.AddContent(24, ChildContent);
 
-                if (_children.All(x => x is FluentCxDropZone<TItem>))
+                var children = ReorderChildrenFromLayout();
+
+                foreach (var child in children)
                 {
-                    foreach (var child in _children.OfType<FluentCxDropZone<TItem>>())
+                    if (child is FluentCxDropZone<TItem> c)
                     {
-                        child.RenderInternal();
+                        c.RenderInternal();
                     }
-                }
-                else
-                {
-                    foreach (var item in _children.OfType<IDropZoneComponent<TItem>>())
+                    else if (child is IDropZoneComponent<TItem> dzc && dzc.Value is not null)
                     {
-                        if (item.Value is not null)
-                        {
-                            builder2.AddContent(25, _renderItem(item.Value));
-                        }
+                        builder2.AddContent(25, _renderItem(dzc.Value));
                     }
                 }
             }
             else if (Items is not null &&
                     Items.Count > 0)
             {
+                var items = ReorderItemsFromLayout();
+
                 if (Virtualize)
                 {
                     builder2.OpenComponent<Virtualize<TItem>>(26);
-                    builder2.AddComponentParameter(27, nameof(Virtualize<TItem>.Items), RuntimeHelpers.TypeCheck(Items));
+                    builder2.AddComponentParameter(27, nameof(Virtualize<TItem>.Items), RuntimeHelpers.TypeCheck(items));
                     builder2.AddComponentParameter(28, nameof(Virtualize<TItem>.ItemSize), RuntimeHelpers.TypeCheck(ItemSize));
                     builder2.AddAttribute(29, "ChildContent", (RenderFragment<TItem>)((context) => (__builder3) =>
                     {
@@ -554,7 +815,7 @@ internal sealed class FluentCxDropZoneContainer<TItem>
                 }
                 else
                 {
-                    foreach (var item in Items)
+                    foreach (var item in items)
                     {
                         builder2.AddContent(31, _renderItem(item));
                     }

--- a/src/Community.Components/Components/TileGrid/FluentCxTileGrid.cs
+++ b/src/Community.Components/Components/TileGrid/FluentCxTileGrid.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.CompilerServices;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.FluentUI.AspNetCore.Components;
+using Microsoft.JSInterop;
 
 namespace FluentUI.Blazor.Community.Components;
 
@@ -13,14 +14,30 @@ namespace FluentUI.Blazor.Community.Components;
 /// <typeparam name="TItem">Type of the component.</typeparam>
 [CascadingTypeParameter(nameof(TItem))]
 public class FluentCxTileGrid<TItem>
-    : FluentComponentBase
+    : FluentComponentBase, IDisposable
 {
+    /// <summary>
+    /// Represents the layout of the tile grid.
+    /// </summary>
+    private readonly TileGridLayout _layout = [];
+
+    /// <summary>
+    /// Represents the javascript file to use to load and to store the layout.
+    /// </summary>
+    private const string JavascriptFile = "./_content/FluentUI.Blazor.Community.Components/js/TileGridLayout.js";
+
+    /// <summary>
+    /// Represents the reference of the javascript object. 
+    /// </summary>
+    private IJSObjectReference? _module;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="FluentCxTileGrid{TItem}"/> component.
     /// </summary>
     public FluentCxTileGrid() : base()
     {
         Id = Identifier.NewId();
+        _layout.SaveRequested += OnSaveRequested;
     }
 
     /// <summary>
@@ -36,6 +53,9 @@ public class FluentCxTileGrid<TItem>
         Width = Width,
         MinimumRowHeight = MinimumRowHeight
     };
+
+    [Inject]
+    private IJSRuntime? JSRuntime { get; set; }
 
     /// <summary>
     /// Gets the <see cref="FluentCxDropZoneContainer{TItem}"/> component.
@@ -154,6 +174,113 @@ public class FluentCxTileGrid<TItem>
     [Parameter]
     public string? Height { get; set; } = "100%";
 
+    /// <summary>
+    /// Gets or sets a value indicating if the layout will be stored in the local storage of the app or not.
+    /// </summary>
+    /// <remarks>
+    /// When this value is set to <see langword="true" />, the <see cref="FluentComponentBase.Id"/> property must be set
+    ///  and mustn't change.</remarks>
+    [Parameter]
+    public bool PersistenceEnabled { get; set; }
+
+    /// <summary>
+    /// Gets or sets the function to extract a key from an item.
+    /// </summary>
+    /// <remarks>This function is only used if <see cref="PersistenceEnabled"/> is set to <see langword="true" />.</remarks>
+    [Parameter]
+    public Func<TItem, string>? ItemKey { get; set; }
+
+    /// <summary>
+    /// Occurs when a save is requested.
+    /// </summary>
+    /// <param name="sender">Object who invokes the method.</param>
+    /// <param name="e">Event args associated to this event.</param>
+    private async void OnSaveRequested(object? sender, EventArgs e)
+    {
+        await SaveLayoutAsync();
+    }
+
+    /// <summary>
+    /// Adds a layout item.
+    /// </summary>
+    /// <param name="value">Item to add.</param>
+    /// <param name="index">Index of the item.</param>
+    internal void AddLayoutItem(FluentCxTileGridItem<TItem>? value, int? index)
+    {
+        if (index.HasValue && value is not null && ItemKey is not null)
+        {
+            _layout.Add<TileGridLayoutItem>(ItemKey(value.Value), index.Value);
+        }
+    }
+
+    /// <summary>
+    /// Remove a layout item.
+    /// </summary>
+    /// <param name="index">Index of the item to remove.</param>
+    internal void RemoveLayoutItem(int? index)
+    {
+        if (index.HasValue)
+        {
+            _layout.Remove(index.Value);
+        }
+    }
+
+    /// <summary>
+    /// Update the layout in an asynchronous way.
+    /// </summary>
+    /// <param name="value">Item to update.</param>
+    /// <returns></returns>
+    internal async Task UpdateLayoutAsync(FluentCxTileGridItem<TItem> value)
+    {
+        if (ItemKey is not null)
+        {
+            _layout.UpdateSpan(ItemKey(value.Value), value.ColumnSpan, value.RowSpan);
+            await SaveLayoutAsync();
+        }
+    }
+
+    /// <summary>
+    /// Save the layout in an asynchronous way.
+    /// </summary>
+    /// <returns>Returns a task which saves the layout when completed.</returns>
+    private async Task SaveLayoutAsync()
+    {
+        if (PersistenceEnabled &&
+            _layout is not null &&
+            _module is not null &&
+            !string.IsNullOrEmpty(Id))
+        {
+            await _module.InvokeVoidAsync(
+                "saveLayout", Id, _layout.Items);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+
+        if (PersistenceEnabled && ItemKey is null)
+        {
+            throw new InvalidOperationException("When PersistenceEnabled is set to true, ItemKey must be defined.");
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+
+        if (firstRender &&
+            JSRuntime is not null &&
+            PersistenceEnabled)
+        {
+            _module = await JSRuntime.InvokeAsync<IJSObjectReference>("import", JavascriptFile);
+            _layout.AddRange(await _module.InvokeAsync<IEnumerable<TileGridLayoutItem>>("loadLayout", Id));
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
     /// <inheritdoc />
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
@@ -177,7 +304,9 @@ public class FluentCxTileGrid<TItem>
             __builder2.AddComponentParameter(14, nameof(FluentCxDropZoneContainer<TItem>.ItemContent), ItemContent);
             __builder2.AddComponentParameter(15, nameof(FluentCxDropZoneContainer<TItem>.TileGridSettings), GridSettings);
             __builder2.AddComponentParameter(16, nameof(FluentCxDropZoneContainer<TItem>.CanOverflow), CanOverflow);
-            __builder2.AddComponentReferenceCapture(17, (__value) =>
+            __builder2.AddComponentParameter(17, nameof(FluentCxDropZoneContainer<TItem>.Layout), _layout);
+            __builder2.AddComponentParameter(18, nameof(FluentCxDropZoneContainer<TItem>.ItemKey), ItemKey);
+            __builder2.AddComponentReferenceCapture(19, (__value) =>
             {
                 _dropContainer = (FluentCxDropZoneContainer<TItem>)__value;
             }
@@ -186,5 +315,12 @@ public class FluentCxTileGrid<TItem>
         });
 
         builder.CloseComponent();
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _layout.SaveRequested -= OnSaveRequested;
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/Community.Components/Components/TileGrid/FluentCxTileGridItem.razor
+++ b/src/Community.Components/Components/TileGrid/FluentCxTileGridItem.razor
@@ -22,7 +22,7 @@
                              SpanGridId="@Parent?.Id"
                              OnTapped="@OnTapped"
                              OnDoubleTapped="@OnDoubleTapped"
-                             OnResized="@OnResized"
+                             OnResized="@OnResizedAsync"
                              IsResizeEnabled=@(Parent?.CanResize ?? false)>
                 <div style="width: 100%; height: 100%;">
                     @ChildContent

--- a/src/Community.Components/Components/TileGrid/IDropZoneComponent.cs
+++ b/src/Community.Components/Components/TileGrid/IDropZoneComponent.cs
@@ -7,12 +7,8 @@ namespace FluentUI.Blazor.Community.Components;
 /// </summary>
 /// <typeparam name="TItem"></typeparam>
 public interface IDropZoneComponent<TItem>
+    : IItemValue<TItem>
 {
-    /// <summary>
-    /// Gets the value of the drop zone.
-    /// </summary>
-    TItem? Value { get; }
-
     /// <summary>
     /// Gets the identifier of the drop zone.
     /// </summary>

--- a/src/Community.Components/Components/TileGrid/ITileGridItemDropZoneComponent.cs
+++ b/src/Community.Components/Components/TileGrid/ITileGridItemDropZoneComponent.cs
@@ -17,4 +17,11 @@ public interface ITileGridItemDropZoneComponent<TItem>
     /// Gets the row span of the <see cref="FluentCxTileGridItem{TItem}"/>.
     /// </summary>
     int RowSpan { get; }
+
+    /// <summary>
+    /// Sets the span of the item.
+    /// </summary>
+    /// <param name="columnSpan">Column span of the item.</param>
+    /// <param name="rowSpan">Row span of the item.</param>
+    void SetSpan(int columnSpan, int rowSpan);
 }

--- a/src/Community.Components/Components/TileGrid/TileGridLayout.cs
+++ b/src/Community.Components/Components/TileGrid/TileGridLayout.cs
@@ -1,0 +1,26 @@
+
+namespace FluentUI.Blazor.Community.Components;
+
+/// <summary>
+/// Represents the layout of the <see cref="FluentCxTileGrid{TItem}"/>
+/// </summary>
+public sealed class TileGridLayout
+    : GridLayoutBase
+{
+    /// <summary>
+    /// Updates the span of the item.
+    /// </summary>
+    /// <param name="key">Key of the item.</param>
+    /// <param name="columnSpan">Column span of the item.</param>
+    /// <param name="rowSpan">Row span of the item.</param>
+    internal void UpdateSpan(string key, int columnSpan, int rowSpan)
+    {
+        var item = Get<TileGridLayoutItem>(key);
+
+        if (item is not null)
+        {
+            item.ColumnSpan = columnSpan;
+            item.RowSpan = rowSpan;
+        }
+    }
+}

--- a/src/Community.Components/Components/TileGrid/TileGridLayoutItem.cs
+++ b/src/Community.Components/Components/TileGrid/TileGridLayoutItem.cs
@@ -1,0 +1,18 @@
+namespace FluentUI.Blazor.Community.Components;
+
+/// <summary>
+/// Represents an item for the <see cref="TileGridLayout"/>.
+/// </summary>
+public class TileGridLayoutItem
+    : GridLayoutBaseItem
+{
+    /// <summary>
+    /// Gets or sets the column span of the item.
+    /// </summary>
+    public int ColumnSpan { get; set; }
+
+    /// <summary>
+    /// Gets or sets the row span of the item.
+    /// </summary>
+    public int RowSpan { get; set; }
+}

--- a/src/Community.Components/FluentUI.Blazor.Community.Components.csproj
+++ b/src/Community.Components/FluentUI.Blazor.Community.Components.csproj
@@ -40,6 +40,7 @@
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
+    <None Include="wwwroot\js\TileGridLayout.js" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Community.Components/wwwroot/js/TileGridLayout.js
+++ b/src/Community.Components/wwwroot/js/TileGridLayout.js
@@ -1,0 +1,21 @@
+export function saveLayout(id, items) {
+  if (localStorage == null) {
+    return;
+  }
+
+  localStorage.setItem(id, JSON.stringify(items));
+}
+
+export function loadLayout(id) {
+  if (localStorage == null) {
+    return [];
+  }
+
+  var content = localStorage.getItem(id);
+
+  if (content == null) {
+    return [];
+  }
+
+  return JSON.parse(content);
+}

--- a/tests/FluentUI.Blazor.Community.Components.Tests/Components/TileGrid/DropZoneContainerTests.cs
+++ b/tests/FluentUI.Blazor.Community.Components.Tests/Components/TileGrid/DropZoneContainerTests.cs
@@ -22,6 +22,7 @@ public class DropZoneContainerTests : TestBase
 
         // Assert
         Assert.NotNull(instance);
+        Assert.NotNull(instance.Items);
         Assert.Empty(instance.Items); // Items should be an empty list, not null
         Assert.Null(instance.ItemContent);
         Assert.Null(instance.ItemCss);


### PR DESCRIPTION
adds a tile grid layout for the fluentcxtilegrid

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

Adds a grid layout for the fluentCxTileGrid
The grid layout on the DropZoneContainer is abstract to be able to create other components (like a Kanban)
The GridLayout stores the layout in the LocalStorage of the user

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
