### PR TITLE
Fix an issue with the fluent-button inside the fluentcsresier

### DIFF
--- a/examples/demo/FluentUI.Demo.Shared/Pages/Resizers/Examples/ResizeButtonExample.razor
+++ b/examples/demo/FluentUI.Demo.Shared/Pages/Resizers/Examples/ResizeButtonExample.razor
@@ -1,5 +1,5 @@
 ﻿<FluentCxResizer>
-    <FluentButton Style="width: 100%; height: 100%">
+    <FluentButton>
         Button inside a Resizer Component
     </FluentButton>
 </FluentCxResizer>

--- a/examples/demo/FluentUI.Demo.Shared/Pages/Resizers/Resizers.razor
+++ b/examples/demo/FluentUI.Demo.Shared/Pages/Resizers/Resizers.razor
@@ -12,12 +12,7 @@
 
 <DemoSection Component="typeof(ResizeCardExample)" Title="Resize a card" />
 
-<DemoSection Component="typeof(ResizeButtonExample)" Title="Resize a button">
-    <Description>
-        A component, like a button needs some extra work.
-        You need to add two styles : width to 100% and height to 100%
-    </Description>
-</DemoSection>
+<DemoSection Component="typeof(ResizeButtonExample)" Title="Resize a button" />
 
 <h2 id="documentation">Documentation</h2>
 

--- a/src/Community.Components/Components/Resizer/FluentCxResizer.razor
+++ b/src/Community.Components/Components/Resizer/FluentCxResizer.razor
@@ -17,17 +17,8 @@
             string css = $"fluentcx-resizer-handler fluentcx-resizer-handler-cursor-{item.Key.ToAttributeValue()}";
 
             <div class="@css"
-            style="@item.Value" />
+                 style="@item.Value" />
         }
 
     }
 </div>
-
-<!-- So weird, why I need to do this inside the razor file, instead the css file ? -->
-<style>
-    fluent-button {
-        min-height: calc((var(--base-height-multiplier) + var(--density)) * var(--design-unit) * 1px);
-        height: 100%;
-        width: 100%;
-    }
-</style>

--- a/src/Community.Components/Components/Resizer/FluentCxResizer.razor.css
+++ b/src/Community.Components/Components/Resizer/FluentCxResizer.razor.css
@@ -30,3 +30,9 @@
 .fluentcx-resizer-handler-cursor-nwse {
     cursor: nwse-resize;
 }
+
+::deep fluent-button {
+  min-height: calc((var(--base-height-multiplier) + var(--density)) * var(--design-unit) * 1px);
+  height: 100%;
+  width: 100%;
+}

--- a/tests/FluentUI.Blazor.Community.Components.Tests/Components/Resizer/FluentCxResizerTests.FluentCxResizer_Default.verified.html
+++ b/tests/FluentUI.Blazor.Community.Components.Tests/Components/Resizer/FluentCxResizerTests.FluentCxResizer_Default.verified.html
@@ -5,11 +5,3 @@
   <div class="fluentcx-resizer-handler fluentcx-resizer-handler-cursor-ns" style="left: 0px; right: 0px; bottom: 0px; height: 9px;" b-tewolge03r=""></div>
   <div class="fluentcx-resizer-handler fluentcx-resizer-handler-cursor-nwse" style="right: 0px; bottom: 0px; width: 9px; height: 9px;" b-tewolge03r=""></div>
 </div>
-<style b-tewolge03r="">
-    fluent-button {
-        min-height: calc((var(--base-height-multiplier) + var(--density)) * var(--design-unit) * 1px);
-        height: 100%;
-        width: 100%;
-    }
-
-</style>

--- a/tests/FluentUI.Blazor.Community.Components.Tests/Components/TileGrid/TileGridTests.FluentCxTileGridItem_ChildContent_RendersCorrectly.verified.html
+++ b/tests/FluentUI.Blazor.Community.Components.Tests/Components/TileGrid/TileGridTests.FluentCxTileGridItem_ChildContent_RendersCorrectly.verified.html
@@ -8,14 +8,6 @@
         </div>
       </div>
     </div>
-    <style b-tewolge03r="">
-    fluent-button {
-        min-height: calc((var(--base-height-multiplier) + var(--density)) * var(--design-unit) * 1px);
-        height: 100%;
-        width: 100%;
-    }
-
-    </style>
   </div>
   <div draggable="False" blazor:ondragstart="10" blazor:ondragend="11" role="listitem" blazor:ondragenter="12" blazor:ondragleave="13" class="fluentcx-drop-zone-noselect fluentcx-drop-zone-draggable" style="grid-column-end: span 1; grid-row-end: span 1; padding: calc(var(--design-unit) * 3px); display: grid;">
     <div id="xxx" blazor:onclick="14" blazor:ondblclick="15" class="fluentcx-resizer" style="width: 100%; height: 100%;" b-tewolge03r="">
@@ -25,13 +17,5 @@
         </div>
       </div>
     </div>
-    <style b-tewolge03r="">
-    fluent-button {
-        min-height: calc((var(--base-height-multiplier) + var(--density)) * var(--design-unit) * 1px);
-        height: 100%;
-        width: 100%;
-    }
-
-    </style>
   </div>
 </div>

--- a/tests/FluentUI.Blazor.Community.Components.Tests/Components/TileGrid/TileGridTests.FluentCxTileGridItem_WithCustomSpans_SetsCorrectly.verified.html
+++ b/tests/FluentUI.Blazor.Community.Components.Tests/Components/TileGrid/TileGridTests.FluentCxTileGridItem_WithCustomSpans_SetsCorrectly.verified.html
@@ -9,14 +9,6 @@
       <div class="fluentcx-resizer-handler fluentcx-resizer-handler-cursor-ns" style="left: 0px; right: 0px; bottom: 0px; height: 9px;" b-tewolge03r=""></div>
       <div class="fluentcx-resizer-handler fluentcx-resizer-handler-cursor-nwse" style="right: 0px; bottom: 0px; width: 9px; height: 9px;" b-tewolge03r=""></div>
     </div>
-    <style b-tewolge03r="">
-    fluent-button {
-        min-height: calc((var(--base-height-multiplier) + var(--density)) * var(--design-unit) * 1px);
-        height: 100%;
-        width: 100%;
-    }
-
-    </style>
   </div>
   <div draggable="False" blazor:ondragstart="10" blazor:ondragend="11" role="listitem" blazor:ondragenter="12" blazor:ondragleave="13" class="fluentcx-drop-zone-noselect fluentcx-drop-zone-draggable" style="grid-column-end: span 2; grid-row-end: span 3; padding: calc(var(--design-unit) * 3px); display: grid;">
     <div id="xxx" blazor:onclick="14" blazor:ondblclick="15" class="fluentcx-resizer" style="width: 100%; height: 100%;" b-tewolge03r="">
@@ -27,13 +19,5 @@
       <div class="fluentcx-resizer-handler fluentcx-resizer-handler-cursor-ns" style="left: 0px; right: 0px; bottom: 0px; height: 9px;" b-tewolge03r=""></div>
       <div class="fluentcx-resizer-handler fluentcx-resizer-handler-cursor-nwse" style="right: 0px; bottom: 0px; width: 9px; height: 9px;" b-tewolge03r=""></div>
     </div>
-    <style b-tewolge03r="">
-    fluent-button {
-        min-height: calc((var(--base-height-multiplier) + var(--density)) * var(--design-unit) * 1px);
-        height: 100%;
-        width: 100%;
-    }
-
-    </style>
   </div>
 </div>

--- a/tests/FluentUI.Blazor.Community.Components.Tests/Components/TileGrid/TileGridTests.FluentCxTileGridItem_WithValue_RendersCorrectly.verified.html
+++ b/tests/FluentUI.Blazor.Community.Components.Tests/Components/TileGrid/TileGridTests.FluentCxTileGridItem_WithValue_RendersCorrectly.verified.html
@@ -6,14 +6,6 @@
         <div style="width: 100%; height: 100%;">Item: test-item</div>
       </div>
     </div>
-    <style b-tewolge03r="">
-    fluent-button {
-        min-height: calc((var(--base-height-multiplier) + var(--density)) * var(--design-unit) * 1px);
-        height: 100%;
-        width: 100%;
-    }
-
-    </style>
   </div>
   <div draggable="False" blazor:ondragstart="10" blazor:ondragend="11" role="listitem" blazor:ondragenter="12" blazor:ondragleave="13" class="fluentcx-drop-zone-noselect fluentcx-drop-zone-draggable" style="grid-column-end: span 1; grid-row-end: span 1; padding: calc(var(--design-unit) * 3px); display: grid;">
     <div id="xxx" blazor:onclick="14" blazor:ondblclick="15" class="fluentcx-resizer" style="width: 100%; height: 100%;" b-tewolge03r="">
@@ -21,13 +13,5 @@
         <div style="width: 100%; height: 100%;">Item: test-item</div>
       </div>
     </div>
-    <style b-tewolge03r="">
-    fluent-button {
-        min-height: calc((var(--base-height-multiplier) + var(--density)) * var(--design-unit) * 1px);
-        height: 100%;
-        width: 100%;
-    }
-
-    </style>
   </div>
 </div>


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

Correct an issue with a fluent-button inside the FluentCxResizer...
Instead of having the style inside the fluentcxResizer which cause issues with all fluent-button in the page,
using ::deep in css part resolve the issue...

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

