### PR TITLE
Correct an issue on the javascript...

### DIFF
--- a/src/Community.Components/Components/Cookies/FluentCxCookie.razor.js
+++ b/src/Community.Components/Components/Cookies/FluentCxCookie.razor.js
@@ -1,3 +1,6 @@
+window.dataLayer = window.dataLayer || [];
+function gtag() { dataLayer.push(arguments) };
+
 const injectGAScript = (measurementId) => {
   // Load the Google tag manager script dynamically
   const script = document.createElement('script');


### PR DESCRIPTION
The gtag function was missing in the FluentCxCookie.razor.js script

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

I didn't have a google analytics id, so I haven't see that gtag function must be a function inside the script...
This issue is fixed here...

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
